### PR TITLE
[feat] 전체 비회원들의 핑 리프레쉬 API

### DIFF
--- a/Ping-Api/src/docs/asciidoc/NonMember.adoc
+++ b/Ping-Api/src/docs/asciidoc/NonMember.adoc
@@ -20,3 +20,7 @@ operation::NonMemberControllerTest/updateNonMemberPings[snippets='http-request,r
 [[Post-NonMemberLogin]]
 === 비회원 로그인
 operation::NonMemberControllerTest/loginNonMember[snippets='http-request,request-fields,http-response']
+
+[[Get-RefreshAllNonMemberPings]]
+=== 비회원 모든 핑 갱신
+operation::NonMemberControllerTest/refreshAllNonMemberPings[snippets='http-request,http-response,query-parameters,response-fields']

--- a/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberApi.kt
+++ b/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberApi.kt
@@ -5,4 +5,5 @@ object NonMemberApi {
     const val LOGIN = "$BASE_URL/login"
     const val PING = "$BASE_URL/pings"
     const val PING_NONMEMBERID = "$PING/{nonMemberId}"
+    const val PING_REFRESH_ALL = "$PING/refresh-all"
 }

--- a/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberController.kt
+++ b/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberController.kt
@@ -41,4 +41,9 @@ class NonMemberController(
     fun updateNonMemberPings(@RequestBody request: UpdateNonMemberPings.Request) {
         nonMemberService.updateNonMemberPings(request)
     }
+
+    @GetMapping(NonMemberApi.PING_REFRESH_ALL)
+    fun refreshAllNonMemberPings(@RequestParam uuid: String): GetAllNonMemberPings.Response {
+        return nonMemberService.refreshAllNonMemberPings(uuid)
+    }
 }

--- a/Ping-Api/src/test/kotlin/com/ping/api/nonmember/NonMemberControllerTest.kt
+++ b/Ping-Api/src/test/kotlin/com/ping/api/nonmember/NonMemberControllerTest.kt
@@ -1,6 +1,7 @@
 package com.ping.api.nonmember
 
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper
+import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
 import com.epages.restdocs.apispec.ResourceDocumentation.resource
 import com.epages.restdocs.apispec.ResourceSnippetParameters
 import com.epages.restdocs.apispec.Schema
@@ -295,6 +296,78 @@ class NonMemberControllerTest : BaseRestDocsTest() {
 //                                fieldWithPath("data").description("응답 데이터")
 //                            )
                             .responseSchema(Schema.schema("CommonResponse"))
+                            .build()
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("비회원 모든 핑 리프레쉬")
+    fun refreshAllNonMemberPings() {
+        // given
+        val uuid = "test-uuid"
+        val response = GetAllNonMemberPings.Response(
+            eventName = "Sample Event",
+            nonMembers = listOf(
+                GetAllNonMemberPings.NonMember(nonMemberId = 1, name = "핑핑이1"),
+                GetAllNonMemberPings.NonMember(nonMemberId = 2, name = "핑핑이2")
+            ),
+            px = 127.00001,
+            py = 37.00001,
+            pings = listOf(
+                GetAllNonMemberPings.Ping(
+                    iconLevel = 2,
+                    nonMembers = listOf(
+                        GetAllNonMemberPings.NonMember(nonMemberId = 1, name = "핑핑이1"),
+                        GetAllNonMemberPings.NonMember(nonMemberId = 2, name = "핑핑이2")
+                    ),
+                    url = "https://map.naver.com/p/entry/place/1946678040",
+                    placeName = "호이",
+                    px = 126.971178,
+                    py = 37.5302481
+                )
+            )
+        )
+
+        Mockito.`when`(nonMemberService.refreshAllNonMemberPings(uuid)).thenReturn(response)
+
+        // when
+        val result: ResultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(NonMemberApi.PING_REFRESH_ALL)
+                .param("uuid", uuid)
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+
+        // then
+        result.andExpect(status().isOk)
+            .andDo(
+                MockMvcRestDocumentationWrapper.document(
+                    "nonmember/refreshAllNonMemberPings",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("NonMember")
+                            .description("비회원 모든 핑 리프레쉬")
+                            .queryParameters(
+                                parameterWithName("uuid").description("이벤트 식별자 UUID")
+                            )
+                            .responseFields(
+                                fieldWithPath("eventName").description("이벤트 이름"),
+                                fieldWithPath("px").description("이벤트 중심 경도"),
+                                fieldWithPath("py").description("이벤트 중심 위도"),
+                                fieldWithPath("nonMembers[].nonMemberId").description("비회원의 id"),
+                                fieldWithPath("nonMembers[].name").description("비회원 이름"),
+                                fieldWithPath("pings[].iconLevel").description("아이콘 레벨\n4:가장 많이 겹침\n3:그다음\n2:그다음\n1:나머지"),
+                                fieldWithPath("pings[].nonMembers[].nonMemberId").description("비회원 id"),
+                                fieldWithPath("pings[].nonMembers[].name").description("비회원 이름"),
+                                fieldWithPath("pings[].url").description("장소 URL"),
+                                fieldWithPath("pings[].placeName").description("장소 이름"),
+                                fieldWithPath("pings[].px").description("경도"),
+                                fieldWithPath("pings[].py").description("위도")
+                            )
+                            .responseSchema(Schema.schema("GetAllNonMemberPingsResponse"))
                             .build()
                     )
                 )

--- a/Ping-Application/src/main/kotlin/com/ping/application/nonmember/NonMemberService.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/nonmember/NonMemberService.kt
@@ -198,6 +198,59 @@ class NonMemberService(
         })
     }
 
+    fun refreshAllNonMemberPings(uuid: String): GetAllNonMemberPings.Response {
+        val shareUrl = shareUrlRepository.findByUuid(uuid)
+            ?: throw CustomException(ExceptionContent.INVALID_SHARE_URL)
+
+        val nonMemberList = nonMemberRepository.findAllByShareUrl(shareUrl.id)
+
+        nonMemberList.forEach { nonMember ->
+            val updatedBookmarkUrls = nonMemberBookmarkUrlRepository.findAllByNonMemberId(nonMember.id)
+            val updatedStoreUrls = nonMemberStoreUrlRepository.findAllByNonMemberId(nonMember.id)
+
+            // 새로운 북마크와 스토어 URL에 대한 업데이트 처리
+            handleBookmarkUrls(updatedBookmarkUrls.map { it.bookmarkUrl }, nonMember)
+            handleStoreUrls(updatedStoreUrls.map { it.storeUrl }, nonMember)
+        }
+
+        val nonMembers = nonMemberList.map { nonMember ->
+            GetAllNonMemberPings.NonMember(
+                nonMemberId = nonMember.id,
+                name = nonMember.name
+            )
+        }
+
+        // 핑 데이터 생성 및 아이콘 레벨 할당
+        val nonMemberPlaces = nonMembersToNonMemberPlacesMap(nonMemberList)
+        val pings = nonMemberPlaces.entries.mapIndexed { index, nonMemberPlace ->
+            val level = calculateIconLevel(index, nonMemberPlace.key)
+
+            nonMemberPlace.value.map { bookmarkPair ->
+                GetAllNonMemberPings.Ping(
+                    iconLevel = level,
+                    nonMembers = bookmarkPair.second.map {
+                        GetAllNonMemberPings.NonMember(
+                            nonMemberId = it.id,
+                            name = it.name
+                        )
+                    },
+                    url = bookmarkPair.first.url,
+                    placeName = bookmarkPair.first.name,
+                    px = bookmarkPair.first.px,
+                    py = bookmarkPair.first.py,
+                )
+            }
+        }.flatten()
+
+        return GetAllNonMemberPings.Response(
+            eventName = shareUrl.eventName,
+            nonMembers = nonMembers,
+            px = shareUrl.latitude,
+            py = shareUrl.longtitude,
+            pings = pings
+        )
+    }
+
     private fun createNonMemberUpdateStatus(newNonMember: NonMemberDomain, shareUrlId: Long) {
         // 새로 생성된 비회원을 제외한 기존 비회원 목록 조회
         val existingNonMembers = nonMemberRepository.findAllByShareUrl(shareUrlId)
@@ -312,10 +365,19 @@ class NonMemberService(
         nonMemberPlaceRepository.deleteAll(placesToDelete)
     }
 
-    fun findUrlsToUpdate(existingUrls: List<String>, newUrls: List<String>): Pair<List<String>, List<String>> {
-        val urlsToAdd = newUrls.filterNot { it in existingUrls }
-        val urlsToDelete = existingUrls.filterNot { it in newUrls }
-        return Pair(urlsToAdd, urlsToDelete)
+    private fun calculateIconLevel(index: Int, overlapCount: Int): Int {
+        val mostOverlappedIconLevel = 4
+        val secondOverlappedIconLevel = 3
+        val thirdOverlappedIconLevel = 2
+        val remainderIconLevel = 1
+
+        return when {
+            overlapCount == 1 -> remainderIconLevel
+            index == 0 -> mostOverlappedIconLevel
+            index == 1 -> secondOverlappedIconLevel
+            index == 2 -> thirdOverlappedIconLevel
+            else -> remainderIconLevel
+        }
     }
 
     private fun isBookmarkExists(sid: String): Boolean {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #30 

## 📝작업 내용

- [x] 전체 비회원 멤버 핑 리프레쉬 API
- [x] 전체 비회원 멤버 핑 리프레쉬 테스트 코드
- [x] 전체 비회원 멤버 핑 리프레쉬 RestDocs 설정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 서비스 로직은 fix(NonMemberService): 비회원 멤버 리프레쉬 로직 수정 PR을 확인해주세요
