### PR TITLE
[feat] 추천 모핑 조회 및 추가 API

### DIFF
--- a/Ping-Api/src/docs/asciidoc/NonMember.adoc
+++ b/Ping-Api/src/docs/asciidoc/NonMember.adoc
@@ -5,6 +5,10 @@
 === 비회원 핑 생성
 operation::NonMemberControllerTest/createNonMemberPings[snippets='http-request,request-fields,http-response']
 
+[[Post-RecommendPings]]
+=== 추천 핑 저장
+operation::NonMemberControllerTest/saveRecommendPings[snippets='http-request,http-response,request-fields,response-fields']
+
 [[Get-NonMemberPings]]
 === 전체 핑 불러오기
 operation::NonMemberControllerTest/getAllNonMemberPings[snippets='http-request,http-response,query-parameters,response-body,response-fields']
@@ -12,6 +16,10 @@ operation::NonMemberControllerTest/getAllNonMemberPings[snippets='http-request,h
 [[Get-NonMemberPing]]
 === 개별 핑 불러오기
 operation::NonMemberControllerTest/getNonMemberPing[snippets='http-request,http-response,response-fields']
+
+[[Get-RecommendPings]]
+=== 추천 핑 불러오기
+operation::NonMemberControllerTest/getRecommendPings[snippets='http-request,http-response,query-parameters,response-fields']
 
 [[Put-UpdateNonMemberPings]]
 === 비회원 핑 업데이트

--- a/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberApi.kt
+++ b/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberApi.kt
@@ -6,4 +6,5 @@ object NonMemberApi {
     const val PING = "$BASE_URL/pings"
     const val PING_NONMEMBERID = "$PING/{nonMemberId}"
     const val PING_REFRESH_ALL = "$PING/refresh-all"
+    const val PING_RECOMMEND = "$PING/recommend"
 }

--- a/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberController.kt
+++ b/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberController.kt
@@ -28,6 +28,11 @@ class NonMemberController(
         return nonMemberService.getNonMemberPing(nonMemberId)
     }
 
+    @GetMapping(NonMemberApi.PING_RECOMMEND)
+    fun getRecommendPings(@RequestBody request: GetRecommendPings.Request): GetRecommendPings.Response {
+        return nonMemberService.getRecommendPings(request)
+    }
+
     @PutMapping(NonMemberApi.PING)
     fun updateNonMemberPings(@RequestBody request: UpdateNonMemberPings.Request) {
         nonMemberService.updateNonMemberPings(request)

--- a/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberController.kt
+++ b/Ping-Api/src/main/kotlin/com/ping/api/nonmember/NonMemberController.kt
@@ -18,6 +18,11 @@ class NonMemberController(
         return nonMemberService.createNonMemberPings(request)
     }
 
+    @PostMapping(NonMemberApi.PING_RECOMMEND)
+    fun saveRecommendPings(@RequestBody request: SaveRecommendPings.Request): GetAllNonMemberPings.Response {
+        return nonMemberService.saveRecommendPings(request)
+    }
+
     @GetMapping(NonMemberApi.PING)
     fun getNonMemberPings(@RequestParam uuid: String): GetAllNonMemberPings.Response {
         return nonMemberService.getAllNonMemberPings(uuid)
@@ -29,8 +34,8 @@ class NonMemberController(
     }
 
     @GetMapping(NonMemberApi.PING_RECOMMEND)
-    fun getRecommendPings(@RequestBody request: GetRecommendPings.Request): GetRecommendPings.Response {
-        return nonMemberService.getRecommendPings(request)
+    fun getRecommendPings(@RequestParam uuid: String, @RequestParam radiusInKm: Double): GetRecommendPings.Response {
+        return nonMemberService.getRecommendPings(uuid, radiusInKm)
     }
 
     @PutMapping(NonMemberApi.PING)

--- a/Ping-Api/src/test/kotlin/com/ping/api/nonmember/NonMemberControllerTest.kt
+++ b/Ping-Api/src/test/kotlin/com/ping/api/nonmember/NonMemberControllerTest.kt
@@ -135,15 +135,174 @@ class NonMemberControllerTest : BaseRestDocsTest() {
     }
 
     @Test
+    @DisplayName("추천 핑 저장")
+    fun saveRecommendPings() {
+        // given
+        val request = SaveRecommendPings.Request(
+            uuid = "test",
+            sids = listOf(
+                "1445446311",
+                "1250904288",
+            )
+        )
+
+        val response = GetAllNonMemberPings.Response(
+            eventName = "핑핑이들 여행",
+            neighborhood = "강원도 속초",
+            px = 127.00001,
+            py = 37.00001,
+            pingLastUpdateTime = "16분",
+            recommendPings = listOf(
+                GetRecommendPings.RecommendPing(
+                    sid = "1445446311",
+                    placeName = "꾸아 광교점",
+                    url = "https://map.naver.com/p/entry/place/1445446311",
+                    px = 127.0548454,
+                    py = 37.2938313,
+                ),
+                GetRecommendPings.RecommendPing(
+                    sid = "1250904288",
+                    placeName = "옴레스토랑 광교점",
+                    url = "https://map.naver.com/p/entry/place/1250904288",
+                    px = 127.0505683,
+                    py = 37.2903113,
+                )
+            ),
+            nonMembers = listOf(
+                GetAllNonMemberPings.NonMember(nonMemberId = 1, name = "핑핑이1", profileSvg = "https://kr.object.ncloudstorage.com/moping-image/profile1.svg"),
+                GetAllNonMemberPings.NonMember(nonMemberId = 2, name = "핑핑이2", profileSvg = "https://kr.object.ncloudstorage.com/moping-image/profile1.svg")
+            ),
+            pings = listOf(
+                GetAllNonMemberPings.Ping(
+                    iconLevel = 2,
+                    nonMembers = listOf(
+                        GetAllNonMemberPings.NonMember(nonMemberId = 1, name = "핑핑이1", profileSvg = "https://kr.object.ncloudstorage.com/moping-image/profile1.svg"),
+                        GetAllNonMemberPings.NonMember(nonMemberId = 2, name = "핑핑이2", profileSvg = "https://kr.object.ncloudstorage.com/moping-image/profile1.svg")
+                    ),
+                    url = "https://map.naver.com/p/entry/place/1946678040",
+                    placeName = "호이",
+                    px = 126.971178,
+                    py = 37.5302481
+                ),
+                GetAllNonMemberPings.Ping(
+                    iconLevel = 1,
+                    nonMembers = listOf(
+                        GetAllNonMemberPings.NonMember(nonMemberId = 1, name = "핑핑이1", profileSvg = "https://kr.object.ncloudstorage.com/moping-image/profile1.svg"),
+                    ),
+                    url = "https://map.naver.com/p/entry/place/1492901893",
+                    placeName = "퍼즈앤스틸",
+                    px = 126.9713426,
+                    py = 37.5303303
+                )
+            )
+        )
+
+        given(nonMemberService.saveRecommendPings(request)).willReturn(response)
+
+        // when
+        val result: ResultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders.post(NonMemberApi.PING_RECOMMEND)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+
+        // then
+        result.andExpect(status().isOk)
+            .andDo( // rest docs
+                resultHandler.document(
+                    requestFields(
+                        fieldWithPath("uuid").description("이벤트 식별자 UUID"),
+                        fieldWithPath("sids").description("추천 장소 ID 리스트"),
+                    ),
+                    responseFields(
+                        fieldWithPath("eventName").description("이벤트 이름"),
+                        fieldWithPath("neighborhood").description("추천 지역 이름"),
+                        fieldWithPath("px").description("중심 경도"),
+                        fieldWithPath("py").description("중심 위도"),
+                        fieldWithPath("pingLastUpdateTime").description("마지막 핑 업데이트 시간"),
+                        fieldWithPath("recommendPings[].sid").description("추천 장소 ID"),
+                        fieldWithPath("recommendPings[].placeName").description("추천 장소 이름"),
+                        fieldWithPath("recommendPings[].url").description("추천 장소 URL"),
+                        fieldWithPath("recommendPings[].px").description("추천 장소 경도"),
+                        fieldWithPath("recommendPings[].py").description("추천 장소 위도"),
+                        fieldWithPath("nonMembers[].nonMemberId").description("비회원의 id"),
+                        fieldWithPath("nonMembers[].name").description("비회원 이름"),
+                        fieldWithPath("nonMembers[].profileSvg").description("프로필 svg url"),
+                        fieldWithPath("pings[].iconLevel").description("아이콘 레벨\n4:가장 많이 겹침\n3:그다음\n2:그다음\n1:나머지"),
+                        fieldWithPath("pings[].nonMembers[].nonMemberId").description("비회원 id"),
+                        fieldWithPath("pings[].nonMembers[].name").description("비회원 이름"),
+                        fieldWithPath("pings[].nonMembers[].profileSvg").description("프로필 svg url"),
+                        fieldWithPath("pings[].url").description("장소 url"),
+                        fieldWithPath("pings[].placeName").description("장소 이름"),
+                        fieldWithPath("pings[].px").description("경도"),
+                        fieldWithPath("pings[].py").description("위도"),
+                    )
+                )
+            )
+            .andDo( // swagger
+                MockMvcRestDocumentationWrapper.document(
+                    identifier = "추천 핑 저장",
+                    resourceDetails = ResourceSnippetParametersBuilder()
+                        .tag(tag)
+                        .description("추천 핑 저장")
+                        .requestFields(
+                            fieldWithPath("uuid").description("이벤트 식별자 UUID"),
+                            fieldWithPath("sids").description("추천 장소 ID 리스트"),
+                        )
+                        .responseFields(
+                            fieldWithPath("eventName").description("이벤트 이름"),
+                            fieldWithPath("neighborhood").description("추천 지역 이름"),
+                            fieldWithPath("px").description("중심 경도"),
+                            fieldWithPath("py").description("중심 위도"),
+                            fieldWithPath("pingLastUpdateTime").description("마지막 핑 업데이트 시간"),
+                            fieldWithPath("recommendPings[].sid").description("추천 장소 ID"),
+                            fieldWithPath("recommendPings[].placeName").description("추천 장소 이름"),
+                            fieldWithPath("recommendPings[].url").description("추천 장소 URL"),
+                            fieldWithPath("recommendPings[].px").description("추천 장소 경도"),
+                            fieldWithPath("recommendPings[].py").description("추천 장소 위도"),
+                            fieldWithPath("nonMembers[].nonMemberId").description("비회원의 id"),
+                            fieldWithPath("nonMembers[].name").description("비회원 이름"),
+                            fieldWithPath("nonMembers[].profileSvg").description("프로필 svg url"),
+                            fieldWithPath("pings[].iconLevel").description("아이콘 레벨\n4:가장 많이 겹침\n3:그다음\n2:그다음\n1:나머지"),
+                            fieldWithPath("pings[].nonMembers[].nonMemberId").description("비회원 id"),
+                            fieldWithPath("pings[].nonMembers[].name").description("비회원 이름"),
+                            fieldWithPath("pings[].nonMembers[].profileSvg").description("프로필 svg url"),
+                            fieldWithPath("pings[].url").description("장소 url"),
+                            fieldWithPath("pings[].placeName").description("장소 이름"),
+                            fieldWithPath("pings[].px").description("경도"),
+                            fieldWithPath("pings[].py").description("위도"),
+                        )
+                )
+            )
+    }
+
+    @Test
     @DisplayName("전체 핑 불러오기")
     fun getAllNonMemberPings() {
         // given
         val uuid = "test"
         val response = GetAllNonMemberPings.Response(
             eventName = "핑핑이들 여행",
+            neighborhood = "강원도 속초",
             px = 127.00001,
             py = 37.00001,
             pingLastUpdateTime = "16분",
+            recommendPings = listOf(
+                GetRecommendPings.RecommendPing(
+                    sid = "1445446311",
+                    placeName = "꾸아 광교점",
+                    url = "https://map.naver.com/p/entry/place/1445446311",
+                    px = 127.0548454,
+                    py = 37.2938313,
+                ),
+                GetRecommendPings.RecommendPing(
+                    sid = "1250904288",
+                    placeName = "옴레스토랑 광교점",
+                    url = "https://map.naver.com/p/entry/place/1250904288",
+                    px = 127.0505683,
+                    py = 37.2903113,
+                )
+            ),
             nonMembers = listOf(
                 GetAllNonMemberPings.NonMember(nonMemberId = 1, name = "핑핑이1", profileSvg = "https://kr.object.ncloudstorage.com/moping-image/profile1.svg"),
                 GetAllNonMemberPings.NonMember(nonMemberId = 2, name = "핑핑이2", profileSvg = "https://kr.object.ncloudstorage.com/moping-image/profile1.svg")
@@ -191,9 +350,15 @@ class NonMemberControllerTest : BaseRestDocsTest() {
                     ),
                     responseFields(
                         fieldWithPath("eventName").description("이벤트 이름"),
-                        fieldWithPath("px").description("이벤트 중심 경도"),
-                        fieldWithPath("py").description("이벤트 중심 위도"),
-                        fieldWithPath("pingLastUpdateTime").description("마지막으로 업데이트 된 시간"),
+                        fieldWithPath("neighborhood").description("추천 지역 이름"),
+                        fieldWithPath("px").description("중심 경도"),
+                        fieldWithPath("py").description("중심 위도"),
+                        fieldWithPath("pingLastUpdateTime").description("마지막 핑 업데이트 시간"),
+                        fieldWithPath("recommendPings[].sid").description("추천 장소 ID"),
+                        fieldWithPath("recommendPings[].placeName").description("추천 장소 이름"),
+                        fieldWithPath("recommendPings[].url").description("추천 장소 URL"),
+                        fieldWithPath("recommendPings[].px").description("추천 장소 경도"),
+                        fieldWithPath("recommendPings[].py").description("추천 장소 위도"),
                         fieldWithPath("nonMembers[].nonMemberId").description("비회원의 id"),
                         fieldWithPath("nonMembers[].name").description("비회원 이름"),
                         fieldWithPath("nonMembers[].profileSvg").description("프로필 svg url"),
@@ -219,9 +384,15 @@ class NonMemberControllerTest : BaseRestDocsTest() {
                         )
                         .responseFields(
                             fieldWithPath("eventName").description("이벤트 이름"),
-                            fieldWithPath("px").description("이벤트 중심 경도"),
-                            fieldWithPath("py").description("이벤트 중심 위도"),
-                            fieldWithPath("pingLastUpdateTime").description("마지막으로 업데이트 된 시간"),
+                            fieldWithPath("neighborhood").description("추천 지역 이름"),
+                            fieldWithPath("px").description("중심 경도"),
+                            fieldWithPath("py").description("중심 위도"),
+                            fieldWithPath("pingLastUpdateTime").description("마지막 핑 업데이트 시간"),
+                            fieldWithPath("recommendPings[].sid").description("추천 장소 ID"),
+                            fieldWithPath("recommendPings[].placeName").description("추천 장소 이름"),
+                            fieldWithPath("recommendPings[].url").description("추천 장소 URL"),
+                            fieldWithPath("recommendPings[].px").description("추천 장소 경도"),
+                            fieldWithPath("recommendPings[].py").description("추천 장소 위도"),
                             fieldWithPath("nonMembers[].nonMemberId").description("비회원의 id"),
                             fieldWithPath("nonMembers[].name").description("비회원 이름"),
                             fieldWithPath("nonMembers[].profileSvg").description("프로필 svg url"),
@@ -297,6 +468,78 @@ class NonMemberControllerTest : BaseRestDocsTest() {
     }
 
     @Test
+    @DisplayName("추천 핑 조회")
+    fun getRecommendPings() {
+        // given
+        val uuid = "test"
+        val radiusInKm = 1.0
+        val response = GetRecommendPings.Response(
+            recommendPings = listOf(
+                GetRecommendPings.RecommendPing(
+                    sid = "1445446311",
+                    placeName = "꾸아 광교점",
+                    url = "https://map.naver.com/p/entry/place/1445446311",
+                    px = 127.0548454,
+                    py = 37.2938313,
+                ),
+                GetRecommendPings.RecommendPing(
+                    sid = "1250904288",
+                    placeName = "옴레스토랑 광교점",
+                    url = "https://map.naver.com/p/entry/place/1250904288",
+                    px = 127.0505683,
+                    py = 37.2903113,
+                )
+            ),
+        )
+        given(nonMemberService.getRecommendPings(uuid, radiusInKm)).willReturn(response)
+
+        // when
+        val result: ResultActions = mockMvc.perform(
+            RestDocumentationRequestBuilders.get(NonMemberApi.PING_RECOMMEND)
+                .contentType(MediaType.APPLICATION_JSON)
+                .queryParam("uuid", uuid)
+                .queryParam("radiusInKm", radiusInKm.toString())
+        )
+
+        // then
+        result.andExpect(status().isOk)
+            .andDo( // rest docs
+                resultHandler.document(
+                    queryParameters(
+                        RequestDocumentation.parameterWithName("uuid").description("이벤트 식별자 UUID"),
+                        RequestDocumentation.parameterWithName("radiusInKm").description("추천 반경 범위 (km)"),
+                    ),
+                    responseFields(
+                        fieldWithPath("recommendPings[].sid").description("추천 장소 ID"),
+                        fieldWithPath("recommendPings[].placeName").description("추천 장소 이름"),
+                        fieldWithPath("recommendPings[].url").description("추천 장소 URL"),
+                        fieldWithPath("recommendPings[].px").description("추천 장소 경도"),
+                        fieldWithPath("recommendPings[].py").description("추천 장소 위도"),
+                    )
+                )
+            )
+            .andDo( // swagger
+                MockMvcRestDocumentationWrapper.document(
+                    identifier = "추천 핑 조회",
+                    resourceDetails = ResourceSnippetParametersBuilder()
+                        .tag(tag)
+                        .description("추천 핑 조회")
+                        .queryParameters(
+                            parameterWithName("uuid").description("이벤트 식별자 UUID"),
+                            parameterWithName("radiusInKm").description("추천 반경 범위 (km)")
+                        )
+                        .responseFields(
+                            fieldWithPath("recommendPings[].sid").description("추천 장소 ID"),
+                            fieldWithPath("recommendPings[].placeName").description("추천 장소 이름"),
+                            fieldWithPath("recommendPings[].url").description("추천 장소 URL"),
+                            fieldWithPath("recommendPings[].px").description("추천 장소 경도"),
+                            fieldWithPath("recommendPings[].py").description("추천 장소 위도"),
+                        )
+                )
+            )
+    }
+
+    @Test
     @DisplayName("비회원 핑 업데이트")
     fun updateNonMemberPings() {
         // given
@@ -344,9 +587,26 @@ class NonMemberControllerTest : BaseRestDocsTest() {
     @DisplayName("비회원 모든 핑 리프레쉬")
     fun refreshAllNonMemberPings() {
         // given
-        val uuid = "test-uuid"
+        val uuid = "test"
         val response = GetAllNonMemberPings.Response(
-            eventName = "Sample Event",
+            eventName = "수원 광교 힙쟁이들",
+            neighborhood = "수원 광교",
+            recommendPings = listOf(
+                GetRecommendPings.RecommendPing(
+                    sid = "1445446311",
+                    placeName = "꾸아 광교점",
+                    url = "https://map.naver.com/p/entry/place/1445446311",
+                    px = 127.0548454,
+                    py = 37.2938313,
+                ),
+                GetRecommendPings.RecommendPing(
+                    sid = "1250904288",
+                    placeName = "옴레스토랑 광교점",
+                    url = "https://map.naver.com/p/entry/place/1250904288",
+                    px = 127.0505683,
+                    py = 37.2903113,
+                )
+            ),
             nonMembers = listOf(
                 GetAllNonMemberPings.NonMember(nonMemberId = 1, name = "핑핑이1", profileSvg = "https://kr.object.ncloudstorage.com/moping-image/profile1.svg"),
                 GetAllNonMemberPings.NonMember(nonMemberId = 2, name = "핑핑이2", profileSvg = "https://kr.object.ncloudstorage.com/moping-image/profile1.svg")
@@ -386,9 +646,15 @@ class NonMemberControllerTest : BaseRestDocsTest() {
                     ),
                     responseFields(
                         fieldWithPath("eventName").description("이벤트 이름"),
-                        fieldWithPath("px").description("이벤트 중심 경도"),
-                        fieldWithPath("py").description("이벤트 중심 위도"),
-                        fieldWithPath("pingLastUpdateTime").description("마지막으로 업데이트 된 시간"),
+                        fieldWithPath("neighborhood").description("추천 지역 이름"),
+                        fieldWithPath("px").description("중심 경도"),
+                        fieldWithPath("py").description("중심 위도"),
+                        fieldWithPath("pingLastUpdateTime").description("마지막 핑 업데이트 시간"),
+                        fieldWithPath("recommendPings[].sid").description("추천 장소 ID"),
+                        fieldWithPath("recommendPings[].placeName").description("추천 장소 이름"),
+                        fieldWithPath("recommendPings[].url").description("추천 장소 URL"),
+                        fieldWithPath("recommendPings[].px").description("추천 장소 경도"),
+                        fieldWithPath("recommendPings[].py").description("추천 장소 위도"),
                         fieldWithPath("nonMembers[].nonMemberId").description("비회원의 id"),
                         fieldWithPath("nonMembers[].name").description("비회원 이름"),
                         fieldWithPath("nonMembers[].profileSvg").description("프로필 svg url"),
@@ -415,9 +681,15 @@ class NonMemberControllerTest : BaseRestDocsTest() {
                         )
                         .responseFields(
                             fieldWithPath("eventName").description("이벤트 이름"),
-                            fieldWithPath("px").description("이벤트 중심 경도"),
-                            fieldWithPath("py").description("이벤트 중심 위도"),
-                            fieldWithPath("pingLastUpdateTime").description("마지막으로 업데이트 된 시간"),
+                            fieldWithPath("neighborhood").description("추천 지역 이름"),
+                            fieldWithPath("px").description("중심 경도"),
+                            fieldWithPath("py").description("중심 위도"),
+                            fieldWithPath("pingLastUpdateTime").description("마지막 핑 업데이트 시간"),
+                            fieldWithPath("recommendPings[].sid").description("추천 장소 ID"),
+                            fieldWithPath("recommendPings[].placeName").description("추천 장소 이름"),
+                            fieldWithPath("recommendPings[].url").description("추천 장소 URL"),
+                            fieldWithPath("recommendPings[].px").description("추천 장소 경도"),
+                            fieldWithPath("recommendPings[].py").description("추천 장소 위도"),
                             fieldWithPath("nonMembers[].nonMemberId").description("비회원의 id"),
                             fieldWithPath("nonMembers[].name").description("비회원 이름"),
                             fieldWithPath("nonMembers[].profileSvg").description("프로필 svg url"),

--- a/Ping-Application/src/main/kotlin/com/ping/application/nonmember/NonMemberService.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/nonmember/NonMemberService.kt
@@ -129,6 +129,21 @@ class NonMemberService(
         return createPingResponse(shareUrl, nonMemberList)
     }
 
+    fun getTopSidCountsForNearbyPlaces(px: Double, py: Double, distanceKm: Double): List<String> {
+        // 1. 주어진 px, py 좌표에서 반경 내의 SIDs를 MongoDB로부터 조회
+        val nearbySids = bookmarkRepository.findNearbySids(px, py, distanceKm)
+
+        // 2. 해당 SID들을 한 번에 조회하여 각 SID의 등장 횟수를 계산
+        val sidCountsMap = nonMemberPlaceRepository.findCountBySidIn(nearbySids)
+            .toMap()  // Pair<String, Long> 리스트를 Map<String, Long>으로 변환
+
+        // 3. 등장 횟수에 따라 정렬 후 상위 5개의 SID를 추출
+        return sidCountsMap.entries
+            .sortedByDescending { it.value } // 횟수를 기준으로 내림차순 정렬
+            .take(5)
+            .map { it.key } // SID만 리스트로 반환
+    }
+
     private fun handleBookmarkUrls(
         bookmarkUrls: List<String>
     ): Set<String> {

--- a/Ping-Application/src/main/kotlin/com/ping/application/nonmember/NonMemberService.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/nonmember/NonMemberService.kt
@@ -274,6 +274,7 @@ class NonMemberService(
 
         return GetAllNonMemberPings.Response(
             eventName = shareUrl.eventName,
+            neighborhood = shareUrl.neighborhood,
             px = shareUrl.px,
             py = shareUrl.py,
             pingLastUpdateTime = pingLastUpdateTime,

--- a/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetAllNonMemberPings.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetAllNonMemberPings.kt
@@ -9,6 +9,7 @@ class GetAllNonMemberPings {
         val px: Double,
         val py: Double,
         val pingLastUpdateTime: String?,
+        val recommendPings: List<GetRecommendPings.RecommendPing?>,
         val nonMembers: List<NonMember>,
         val pings: List<Ping>,
     )

--- a/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetAllNonMemberPings.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetAllNonMemberPings.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 class GetAllNonMemberPings {
     data class Response(
         val eventName: String,
+        val neighborhood: String,
         val px: Double,
         val py: Double,
         val pingLastUpdateTime: String?,

--- a/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetRecommendPings.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetRecommendPings.kt
@@ -1,0 +1,20 @@
+package com.ping.application.nonmember.dto
+
+interface GetRecommendPings {
+    data class Request(
+        val px: Double,
+        val py: Double,
+        val radiusInKm: Double,
+    )
+
+    data class Response(
+        val pings: List<RecommendPing>,
+    )
+
+    data class RecommendPing(
+        val placeName: String,
+        val url: String,
+        val px: Double,
+        val py: Double,
+    )
+}

--- a/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetRecommendPings.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetRecommendPings.kt
@@ -2,8 +2,7 @@ package com.ping.application.nonmember.dto
 
 interface GetRecommendPings {
     data class Request(
-        val px: Double,
-        val py: Double,
+        val uuid: String,
         val radiusInKm: Double,
     )
 

--- a/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetRecommendPings.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/GetRecommendPings.kt
@@ -1,16 +1,12 @@
 package com.ping.application.nonmember.dto
 
 interface GetRecommendPings {
-    data class Request(
-        val uuid: String,
-        val radiusInKm: Double,
-    )
-
     data class Response(
-        val pings: List<RecommendPing>,
+        val recommendPings: List<RecommendPing>,
     )
 
     data class RecommendPing(
+        val sid: String,
         val placeName: String,
         val url: String,
         val px: Double,

--- a/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/SaveRecommendPings.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/nonmember/dto/SaveRecommendPings.kt
@@ -1,0 +1,8 @@
+package com.ping.application.nonmember.dto
+
+interface SaveRecommendPings {
+    data class Request(
+        val uuid: String,
+        val sids: List<String>,
+    )
+}

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/aggregate/BookmarkDomain.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/aggregate/BookmarkDomain.kt
@@ -7,5 +7,5 @@ data class BookmarkDomain (
     val sid: String,
     val address: String,
     val mcidName: String,
-    val url: String
+    val url: String,
 )

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/aggregate/RecommendPlaceDomain.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/aggregate/RecommendPlaceDomain.kt
@@ -1,0 +1,8 @@
+package com.ping.domain.nonmember.aggregate
+
+class RecommendPlaceDomain(
+    val id: Long,
+    val shareUrlDomain: ShareUrlDomain,
+    val sid: String
+) {
+}

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/aggregate/RecommendPlaceDomain.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/aggregate/RecommendPlaceDomain.kt
@@ -5,4 +5,11 @@ class RecommendPlaceDomain(
     val shareUrlDomain: ShareUrlDomain,
     val sid: String
 ) {
+    companion object {
+        fun of(shareUrl: ShareUrlDomain, sid: String) = RecommendPlaceDomain(
+                id = 0L,
+                shareUrlDomain = shareUrl,
+                sid = sid,
+            )
+    }
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/dto/SidCount.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/dto/SidCount.kt
@@ -1,0 +1,6 @@
+package com.ping.domain.nonmember.dto
+
+data class SidCount(
+    val sid: String,
+    val count: Long,
+)

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/BookmarkRepository.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/BookmarkRepository.kt
@@ -6,4 +6,5 @@ interface BookmarkRepository {
     fun saveAll(bookmarkDomains: List<BookmarkDomain>) : List<BookmarkDomain>
 
     fun findAllBySidIn(sids: List<String>) : List<BookmarkDomain>
+    fun findByLocationNear(px: Double, py: Double, distance: Double): List<BookmarkDomain>
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/BookmarkRepository.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/BookmarkRepository.kt
@@ -6,5 +6,5 @@ interface BookmarkRepository {
     fun saveAll(bookmarkDomains: List<BookmarkDomain>) : List<BookmarkDomain>
 
     fun findAllBySidIn(sids: List<String>) : List<BookmarkDomain>
-    fun findByLocationNear(px: Double, py: Double, distance: Double): List<BookmarkDomain>
+    fun findAllByLocationNear(px: Double, py: Double, distance: Double): List<BookmarkDomain>
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/NonMemberPlaceRepository.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/NonMemberPlaceRepository.kt
@@ -10,4 +10,6 @@ interface NonMemberPlaceRepository {
     fun deleteAll(ids: List<Long>)
 
     fun findCountBySidIn(sids: List<String>): List<Pair<String, Long>>
+
+    fun findAllByNonMemberIdIn(nonMemberIds: List<Long>): List<NonMemberPlaceDomain>
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/NonMemberPlaceRepository.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/NonMemberPlaceRepository.kt
@@ -6,5 +6,8 @@ interface NonMemberPlaceRepository {
     fun saveAll(nonMemberPlaceDomains: List<NonMemberPlaceDomain>): List<NonMemberPlaceDomain>
 
     fun findAllByNonMemberId(nonMemberId: Long): List<NonMemberPlaceDomain>
+
     fun deleteAll(ids: List<Long>)
+
+    fun findCountBySidIn(sids: List<String>): List<Pair<String, Long>>
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/NonMemberPlaceRepository.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/NonMemberPlaceRepository.kt
@@ -1,6 +1,7 @@
 package com.ping.domain.nonmember.repository
 
 import com.ping.domain.nonmember.aggregate.NonMemberPlaceDomain
+import com.ping.domain.nonmember.dto.SidCount
 
 interface NonMemberPlaceRepository {
     fun saveAll(nonMemberPlaceDomains: List<NonMemberPlaceDomain>): List<NonMemberPlaceDomain>
@@ -9,7 +10,7 @@ interface NonMemberPlaceRepository {
 
     fun deleteAll(ids: List<Long>)
 
-    fun findCountBySidIn(sids: List<String>): List<Pair<String, Long>>
+    fun findCountBySidIn(sids: List<String>): List<SidCount>
 
     fun findAllByNonMemberIdIn(nonMemberIds: List<Long>): List<NonMemberPlaceDomain>
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/RecommendPlaceRepository.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/RecommendPlaceRepository.kt
@@ -1,0 +1,7 @@
+package com.ping.domain.nonmember.repository
+
+import com.ping.domain.nonmember.aggregate.RecommendPlaceDomain
+
+interface RecommendPlaceRepository {
+    fun saveAll(recommendPlaceDomains: List<RecommendPlaceDomain>)
+}

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/RecommendPlaceRepository.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/nonmember/repository/RecommendPlaceRepository.kt
@@ -3,5 +3,7 @@ package com.ping.domain.nonmember.repository
 import com.ping.domain.nonmember.aggregate.RecommendPlaceDomain
 
 interface RecommendPlaceRepository {
-    fun saveAll(recommendPlaceDomains: List<RecommendPlaceDomain>)
+    fun saveAll(recommendPlaceDomains: List<RecommendPlaceDomain>): List<RecommendPlaceDomain>
+
+    fun findAllByShareUrlId(shareUrlId: Long): List<RecommendPlaceDomain>
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/entity/RecommendPlaceEntity.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/entity/RecommendPlaceEntity.kt
@@ -1,0 +1,19 @@
+package com.ping.infra.nonmember.domain.jpa.entity
+
+import com.ping.infra.nonmember.domain.jpa.common.BaseTimeEntity
+import jakarta.persistence.*
+
+@Entity(name = "recommend_place")
+@Table(uniqueConstraints = [UniqueConstraint(columnNames = ["share_url_id", "sid"])])
+class RecommendPlaceEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    val shareUrl: ShareUrlEntity,
+
+    @Column(nullable = false)
+    val sid: String,
+) : BaseTimeEntity()

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/NonMemberPlaceJpaRepository.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/NonMemberPlaceJpaRepository.kt
@@ -9,4 +9,6 @@ interface NonMemberPlaceJpaRepository : JpaRepository<NonMemberPlaceEntity, Long
 
     @Query("SELECT p.sid AS sid, COUNT(p.sid) AS count FROM non_member_place p WHERE p.sid IN :sids GROUP BY p.sid")
     fun findCountBySidIn(sids: List<String>): List<Pair<String, Long>>
+
+    fun findAllByNonMemberIdIn(nonMemberIds: List<Long>): List<NonMemberPlaceEntity>
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/NonMemberPlaceJpaRepository.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/NonMemberPlaceJpaRepository.kt
@@ -2,7 +2,11 @@ package com.ping.infra.nonmember.domain.jpa.repository
 
 import com.ping.infra.nonmember.domain.jpa.entity.NonMemberPlaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface NonMemberPlaceJpaRepository : JpaRepository<NonMemberPlaceEntity, Long> {
     fun findAllByNonMemberId(nonMemberId: Long): List<NonMemberPlaceEntity>
+
+    @Query("SELECT p.sid AS sid, COUNT(p.sid) AS count FROM non_member_place p WHERE p.sid IN :sids GROUP BY p.sid")
+    fun findCountBySidIn(sids: List<String>): List<Pair<String, Long>>
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/NonMemberPlaceJpaRepository.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/NonMemberPlaceJpaRepository.kt
@@ -1,5 +1,6 @@
 package com.ping.infra.nonmember.domain.jpa.repository
 
+import com.ping.domain.nonmember.dto.SidCount
 import com.ping.infra.nonmember.domain.jpa.entity.NonMemberPlaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -7,8 +8,8 @@ import org.springframework.data.jpa.repository.Query
 interface NonMemberPlaceJpaRepository : JpaRepository<NonMemberPlaceEntity, Long> {
     fun findAllByNonMemberId(nonMemberId: Long): List<NonMemberPlaceEntity>
 
-    @Query("SELECT p.sid AS sid, COUNT(p.sid) AS count FROM non_member_place p WHERE p.sid IN :sids GROUP BY p.sid")
-    fun findCountBySidIn(sids: List<String>): List<Pair<String, Long>>
+    @Query("SELECT new com.ping.domain.nonmember.dto.SidCount(p.sid, COUNT(p.sid)) FROM non_member_place p WHERE p.sid IN :sids GROUP BY p.sid")
+    fun findCountBySidIn(sids: List<String>): List<SidCount>
 
     fun findAllByNonMemberIdIn(nonMemberIds: List<Long>): List<NonMemberPlaceEntity>
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/RecommendPlaceJpaRepository.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/RecommendPlaceJpaRepository.kt
@@ -4,4 +4,5 @@ import com.ping.infra.nonmember.domain.jpa.entity.RecommendPlaceEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface RecommendPlaceJpaRepository : JpaRepository<RecommendPlaceEntity, Long> {
+    fun findAllByShareUrlId(shareUrlId: Long): List<RecommendPlaceEntity>
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/RecommendPlaceJpaRepository.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/jpa/repository/RecommendPlaceJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.ping.infra.nonmember.domain.jpa.repository
+
+import com.ping.infra.nonmember.domain.jpa.entity.RecommendPlaceEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RecommendPlaceJpaRepository : JpaRepository<RecommendPlaceEntity, Long> {
+}

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mapper/BookmarkMapper.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mapper/BookmarkMapper.kt
@@ -2,6 +2,7 @@ package com.ping.infra.nonmember.domain.mapper
 
 import com.ping.domain.nonmember.aggregate.BookmarkDomain
 import com.ping.infra.nonmember.domain.mongo.entity.BookmarkEntity
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
 
 object BookmarkMapper {
 
@@ -12,7 +13,7 @@ object BookmarkMapper {
         bookmarkEntity.sid,
         bookmarkEntity.address,
         bookmarkEntity.mcidName,
-        bookmarkEntity.url
+        bookmarkEntity.url,
     )
 
     fun toEntity(bookmarkDomain: BookmarkDomain) = BookmarkEntity(
@@ -22,6 +23,7 @@ object BookmarkMapper {
         bookmarkDomain.sid,
         bookmarkDomain.address,
         bookmarkDomain.mcidName,
-        bookmarkDomain.url
+        bookmarkDomain.url,
+        GeoJsonPoint(bookmarkDomain.px, bookmarkDomain.py),
     )
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mapper/RecommendPlaceMapper.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mapper/RecommendPlaceMapper.kt
@@ -1,0 +1,18 @@
+package com.ping.infra.nonmember.domain.mapper
+
+import com.ping.domain.nonmember.aggregate.RecommendPlaceDomain
+import com.ping.infra.nonmember.domain.jpa.entity.RecommendPlaceEntity
+
+object RecommendPlaceMapper {
+    fun toDomain(recommendPlaceEntity: RecommendPlaceEntity) = RecommendPlaceDomain(
+        id = recommendPlaceEntity.id,
+        shareUrlDomain = ShareUrlMapper.toDomain(recommendPlaceEntity.shareUrl),
+        sid = recommendPlaceEntity.sid,
+    )
+
+    fun toEntity(recommendPlaceDomain: RecommendPlaceDomain) = RecommendPlaceEntity(
+        id = recommendPlaceDomain.id,
+        shareUrl = ShareUrlMapper.toEntity(recommendPlaceDomain.shareUrlDomain),
+        sid = recommendPlaceDomain.sid,
+    )
+}

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mongo/entity/BookmarkEntity.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mongo/entity/BookmarkEntity.kt
@@ -2,6 +2,9 @@ package com.ping.infra.nonmember.domain.mongo.entity
 
 import com.ping.infra.nonmember.domain.mongo.common.BaseTimeMongoEntity
 import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexType
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexed
 import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 
@@ -15,5 +18,7 @@ data class BookmarkEntity(
     val sid: String,
     val address: String,
     val mcidName: String,
-    val url: String
+    val url: String,
+    @GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)
+    val location: GeoJsonPoint = GeoJsonPoint(px, py),
 ): BaseTimeMongoEntity()

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mongo/repository/BookmarkMongoRepository.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mongo/repository/BookmarkMongoRepository.kt
@@ -1,8 +1,11 @@
 package com.ping.infra.nonmember.domain.mongo.repository
 
 import com.ping.infra.nonmember.domain.mongo.entity.BookmarkEntity
+import org.springframework.data.geo.Distance
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
 import org.springframework.data.mongodb.repository.MongoRepository
 
 interface BookmarkMongoRepository : MongoRepository<BookmarkEntity, String> {
     fun findAllBySidIn(sids: List<String>) : List<BookmarkEntity>
+    fun findByLocationNear(location: GeoJsonPoint, distance: Distance): List<BookmarkEntity>
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mongo/repository/BookmarkMongoRepository.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/mongo/repository/BookmarkMongoRepository.kt
@@ -7,5 +7,5 @@ import org.springframework.data.mongodb.repository.MongoRepository
 
 interface BookmarkMongoRepository : MongoRepository<BookmarkEntity, String> {
     fun findAllBySidIn(sids: List<String>) : List<BookmarkEntity>
-    fun findByLocationNear(location: GeoJsonPoint, distance: Distance): List<BookmarkEntity>
+    fun findAllByLocationNear(location: GeoJsonPoint, distance: Distance): List<BookmarkEntity>
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/BookmarkRepositoryImpl.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/BookmarkRepositoryImpl.kt
@@ -4,6 +4,9 @@ import com.ping.domain.nonmember.aggregate.BookmarkDomain
 import com.ping.domain.nonmember.repository.BookmarkRepository
 import com.ping.infra.nonmember.domain.mapper.BookmarkMapper
 import com.ping.infra.nonmember.domain.mongo.repository.BookmarkMongoRepository
+import org.springframework.data.geo.Distance
+import org.springframework.data.geo.Metrics
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -18,6 +21,13 @@ class BookmarkRepositoryImpl(
 
     override fun findAllBySidIn(sids: List<String>): List<BookmarkDomain> {
         return bookmarkMongoRepository.findAllBySidIn(sids).map { BookmarkMapper.toDomain(it) }
+    }
+
+    override fun findByLocationNear(px: Double, py: Double, distance: Double): List<BookmarkDomain> {
+        return bookmarkMongoRepository.findByLocationNear(GeoJsonPoint(px,py), Distance(distance, Metrics.KILOMETERS))
+            .map {
+                BookmarkMapper.toDomain(it)
+            }
     }
 
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/BookmarkRepositoryImpl.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/BookmarkRepositoryImpl.kt
@@ -23,8 +23,8 @@ class BookmarkRepositoryImpl(
         return bookmarkMongoRepository.findAllBySidIn(sids).map { BookmarkMapper.toDomain(it) }
     }
 
-    override fun findByLocationNear(px: Double, py: Double, distance: Double): List<BookmarkDomain> {
-        return bookmarkMongoRepository.findByLocationNear(GeoJsonPoint(px,py), Distance(distance, Metrics.KILOMETERS))
+    override fun findAllByLocationNear(px: Double, py: Double, distance: Double): List<BookmarkDomain> {
+        return bookmarkMongoRepository.findAllByLocationNear(GeoJsonPoint(px,py), Distance(distance, Metrics.KILOMETERS))
             .map {
                 BookmarkMapper.toDomain(it)
             }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/NonMemberPlaceRepositoryImpl.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/NonMemberPlaceRepositoryImpl.kt
@@ -20,4 +20,8 @@ class NonMemberPlaceRepositoryImpl(
     override fun deleteAll(ids: List<Long>) {
         nonMemberPlaceJpaRepository.deleteAllById(ids)
     }
+
+    override fun findCountBySidIn(sids: List<String>): List<Pair<String, Long>> {
+        return nonMemberPlaceJpaRepository.findCountBySidIn(sids)
+    }
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/NonMemberPlaceRepositoryImpl.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/NonMemberPlaceRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.ping.infra.nonmember.domain.repositoryImpl
 
 import com.ping.domain.nonmember.aggregate.NonMemberPlaceDomain
+import com.ping.domain.nonmember.dto.SidCount
 import com.ping.domain.nonmember.repository.NonMemberPlaceRepository
 import com.ping.infra.nonmember.domain.jpa.repository.NonMemberPlaceJpaRepository
 import com.ping.infra.nonmember.domain.mapper.NonMemberPlaceMapper
@@ -21,7 +22,7 @@ class NonMemberPlaceRepositoryImpl(
         nonMemberPlaceJpaRepository.deleteAllById(ids)
     }
 
-    override fun findCountBySidIn(sids: List<String>): List<Pair<String, Long>> {
+    override fun findCountBySidIn(sids: List<String>): List<SidCount> {
         return nonMemberPlaceJpaRepository.findCountBySidIn(sids)
     }
 

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/NonMemberPlaceRepositoryImpl.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/NonMemberPlaceRepositoryImpl.kt
@@ -12,7 +12,7 @@ class NonMemberPlaceRepositoryImpl(
 ) : NonMemberPlaceRepository {
     override fun saveAll(nonMemberPlaceDomains: List<NonMemberPlaceDomain>): List<NonMemberPlaceDomain> {
         return nonMemberPlaceJpaRepository.saveAll(nonMemberPlaceDomains.map { NonMemberPlaceMapper.toEntity(it) })
-            .map { NonMemberPlaceMapper.toDomain(it) }
+                .map { NonMemberPlaceMapper.toDomain(it) }
     }
     override fun findAllByNonMemberId(nonMemberId: Long): List<NonMemberPlaceDomain> {
         return nonMemberPlaceJpaRepository.findAllByNonMemberId(nonMemberId).map { NonMemberPlaceMapper.toDomain(it) }
@@ -23,5 +23,10 @@ class NonMemberPlaceRepositoryImpl(
 
     override fun findCountBySidIn(sids: List<String>): List<Pair<String, Long>> {
         return nonMemberPlaceJpaRepository.findCountBySidIn(sids)
+    }
+
+    override fun findAllByNonMemberIdIn(nonMemberIds: List<Long>): List<NonMemberPlaceDomain> {
+        return nonMemberPlaceJpaRepository.findAllByNonMemberIdIn(nonMemberIds)
+                .map { NonMemberPlaceMapper.toDomain(it) }
     }
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/RecommendPlaceRepositoryImpl.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/RecommendPlaceRepositoryImpl.kt
@@ -4,13 +4,19 @@ import com.ping.domain.nonmember.aggregate.RecommendPlaceDomain
 import com.ping.domain.nonmember.repository.RecommendPlaceRepository
 import com.ping.infra.nonmember.domain.jpa.repository.RecommendPlaceJpaRepository
 import com.ping.infra.nonmember.domain.mapper.RecommendPlaceMapper
+import org.springframework.stereotype.Repository
 
+@Repository
 class RecommendPlaceRepositoryImpl(
     private val recommendPlaceJpaRepository: RecommendPlaceJpaRepository
 ) : RecommendPlaceRepository {
-    override fun saveAll(recommendPlaceDomains: List<RecommendPlaceDomain>) {
-        recommendPlaceJpaRepository.saveAll(recommendPlaceDomains.map { RecommendPlaceMapper.toEntity(it) })
-            .map { RecommendPlaceMapper.toDomain(it) }
+    override fun saveAll(recommendPlaceDomains: List<RecommendPlaceDomain>): List<RecommendPlaceDomain> {
+        return recommendPlaceJpaRepository.saveAll(recommendPlaceDomains.map { RecommendPlaceMapper.toEntity(it) })
+                .map { RecommendPlaceMapper.toDomain(it) }
     }
 
+    override fun findAllByShareUrlId(shareUrlId: Long): List<RecommendPlaceDomain> {
+        return recommendPlaceJpaRepository.findAllByShareUrlId(shareUrlId)
+                .map { RecommendPlaceMapper.toDomain(it) }
+    }
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/RecommendPlaceRepositoryImpl.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/nonmember/domain/repositoryImpl/RecommendPlaceRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.ping.infra.nonmember.domain.repositoryImpl
+
+import com.ping.domain.nonmember.aggregate.RecommendPlaceDomain
+import com.ping.domain.nonmember.repository.RecommendPlaceRepository
+import com.ping.infra.nonmember.domain.jpa.repository.RecommendPlaceJpaRepository
+import com.ping.infra.nonmember.domain.mapper.RecommendPlaceMapper
+
+class RecommendPlaceRepositoryImpl(
+    private val recommendPlaceJpaRepository: RecommendPlaceJpaRepository
+) : RecommendPlaceRepository {
+    override fun saveAll(recommendPlaceDomains: List<RecommendPlaceDomain>) {
+        recommendPlaceJpaRepository.saveAll(recommendPlaceDomains.map { RecommendPlaceMapper.toEntity(it) })
+            .map { RecommendPlaceMapper.toDomain(it) }
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #50

## 📝작업 내용

- [x] 추천 모핑 조회 API
- [x] 추천 모핑 저장 API
- [x] 전체 핑 반환 및 전체 핑 리프레쉬 API 반환값에 추천 모핑 리스트 추가
- [x] 추천 모핑 조회 및 추가 API 테스트 코드 작성
- [x] 전체 핑 반환 및 전체 핑 리프레쉬 API 반환값 변경에 따른 테스트 코드 수정

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/182281ab-7301-437f-a4ef-7957bbaad1e3)
![image](https://github.com/user-attachments/assets/9f855b09-7ed3-4011-879b-5a8c5716eb95)


## 💬리뷰 요구사항(선택)

bookmark 컬렉션 필드가 변경되어서 bookmark 컬렉션만 한번 drop 하고 재생성하였습니다.
bookmark에 값을 추가할때 point 값을 만들어서 넣어주는 로직이라 drop 방법밖에 없었습니다.
