### PR TITLE
[feat] 다른 멤버의 모핑 추가 API 구현

### DIFF
--- a/Ping-Api/src/docs/asciidoc/Pings.adoc
+++ b/Ping-Api/src/docs/asciidoc/Pings.adoc
@@ -13,6 +13,10 @@ operation::PingControllerTest/isCorrectStoreUrl[snippets='http-request,http-resp
 === 비회원 핑 생성
 operation::PingControllerTest/createNonMemberPings[snippets='http-request,request-fields,http-response']
 
+[[Post-SaveMemberPing]]
+=== 회원 핑 저장
+operation::PingControllerTest/saveMemberPing[snippets='http-request,http-response,request-fields']
+
 [[Post-RecommendPings]]
 === 추천 핑 저장
 operation::PingControllerTest/saveRecommendPings[snippets='http-request,http-response,request-fields,response-fields']

--- a/Ping-Api/src/docs/asciidoc/Pings.adoc
+++ b/Ping-Api/src/docs/asciidoc/Pings.adoc
@@ -15,7 +15,7 @@ operation::PingControllerTest/createNonMemberPings[snippets='http-request,reques
 
 [[Post-SaveMemberPing]]
 === 회원 핑 저장
-operation::PingControllerTest/saveMemberPing[snippets='http-request,http-response,request-fields']
+operation::PingControllerTest/saveMemberPing[snippets='http-request,http-response,request-headers,request-fields']
 
 [[Post-RecommendPings]]
 === 추천 핑 저장

--- a/Ping-Api/src/main/kotlin/com/ping/api/ping/PingApi.kt
+++ b/Ping-Api/src/main/kotlin/com/ping/api/ping/PingApi.kt
@@ -7,4 +7,5 @@ object PingApi {
     const val PING_NONMEMBER_ID = "$BASE_URL/{nonMemberId}"
     const val PING_REFRESH_ALL = "$BASE_URL/refresh-all"
     const val PING_RECOMMEND = "$BASE_URL/recommend"
+    const val PING_MEMBER = "$BASE_URL/member"
 }

--- a/Ping-Api/src/main/kotlin/com/ping/api/ping/PingController.kt
+++ b/Ping-Api/src/main/kotlin/com/ping/api/ping/PingController.kt
@@ -4,6 +4,7 @@ import com.ping.application.member.dto.CreateNonMember
 import com.ping.application.ping.dto.*
 import com.ping.application.ping.service.PingService
 import com.ping.domain.ping.service.PingUrlService
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -14,6 +15,14 @@ class PingController(
     @PostMapping(PingApi.BASE_URL)
     fun createNonMemberPings(@RequestBody request: CreateNonMember.Request) {
         return pingService.createNonMemberPings(request)
+    }
+
+    @PostMapping(PingApi.PING_MEMBER)
+    fun saveMemberPing(
+        @RequestBody request: SaveMemberPing.Request,
+        httpRequest: HttpServletRequest,
+    ) {
+        pingService.saveMemberPing(request, httpRequest)
     }
 
     @PostMapping(PingApi.PING_RECOMMEND)

--- a/Ping-Api/src/test/kotlin/com/ping/api/ping/PingControllerTest.kt
+++ b/Ping-Api/src/test/kotlin/com/ping/api/ping/PingControllerTest.kt
@@ -11,6 +11,8 @@ import com.ping.domain.ping.service.PingUrlService
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito
+import org.mockito.Mockito.doNothing
+import org.mockito.kotlin.any
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
@@ -98,6 +100,55 @@ class PingControllerTest : BaseRestDocsTest() {
                         .description("유효한 가게 ")
                         .requestFields(
                             fieldWithPath("url").description("가게 url")
+                        )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("회원 핑 저장")
+    fun saveMemberPing() {
+        // given
+        val request = SaveMemberPing.Request(
+            nonMemberId = 1L,
+            sid = "testSid"
+        )
+        val jsonRequest = """
+            {
+                "nonMemberId": ${request.nonMemberId},
+                "sid": "${request.sid}"
+            }
+        """.trimIndent()
+
+        doNothing().`when`(pingService).saveMemberPing(any(), any())
+
+        // when
+        val result = mockMvc.perform(
+            RestDocumentationRequestBuilders.post(PingApi.PING_MEMBER)
+                .header("Authorization", "Bearer validAccessToken123")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonRequest)
+        )
+
+        // then
+        result.andExpect(status().isOk)
+            .andDo( // REST Docs
+                resultHandler.document(
+                    requestFields(
+                        fieldWithPath("nonMemberId").description("비회원 ID"),
+                        fieldWithPath("sid").description("장소 ID")
+                    )
+                )
+            )
+            .andDo( // Swagger
+                MockMvcRestDocumentationWrapper.document(
+                    identifier = "멤버 핑 저장",
+                    resourceDetails = ResourceSnippetParametersBuilder()
+                        .tag(tag)
+                        .description("멤버의 핑을 저장하는 API")
+                        .requestFields(
+                            fieldWithPath("nonMemberId").description("비회원 ID"),
+                            fieldWithPath("sid").description("장소 ID")
                         )
                 )
             )

--- a/Ping-Api/src/test/kotlin/com/ping/api/ping/PingControllerTest.kt
+++ b/Ping-Api/src/test/kotlin/com/ping/api/ping/PingControllerTest.kt
@@ -16,6 +16,8 @@ import org.mockito.kotlin.any
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
+import org.springframework.restdocs.headers.HeaderDocumentation.headerWithName
+import org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
@@ -29,7 +31,7 @@ class PingControllerTest : BaseRestDocsTest() {
 
     @MockBean
     private lateinit var pingUrlService: PingUrlService
-    
+
     @MockBean
     private lateinit var pingService: PingService
 
@@ -72,7 +74,7 @@ class PingControllerTest : BaseRestDocsTest() {
 
     @Test
     @DisplayName("유효한 가게 링크")
-    fun isCorrectStoreUrl(){
+    fun isCorrectStoreUrl() {
         // given
         val request = IsCorrectUrl.Request("https://naver.me/xecfaJTy")
 
@@ -110,12 +112,10 @@ class PingControllerTest : BaseRestDocsTest() {
     fun saveMemberPing() {
         // given
         val request = SaveMemberPing.Request(
-            nonMemberId = 1L,
             sid = "testSid"
         )
         val jsonRequest = """
             {
-                "nonMemberId": ${request.nonMemberId},
                 "sid": "${request.sid}"
             }
         """.trimIndent()
@@ -134,8 +134,10 @@ class PingControllerTest : BaseRestDocsTest() {
         result.andExpect(status().isOk)
             .andDo( // REST Docs
                 resultHandler.document(
+                    requestHeaders(
+                        headerWithName("Authorization").description("Access Token")
+                    ),
                     requestFields(
-                        fieldWithPath("nonMemberId").description("비회원 ID"),
                         fieldWithPath("sid").description("장소 ID")
                     )
                 )
@@ -146,8 +148,10 @@ class PingControllerTest : BaseRestDocsTest() {
                     resourceDetails = ResourceSnippetParametersBuilder()
                         .tag(tag)
                         .description("멤버의 핑을 저장하는 API")
+                        .requestHeaders(
+                            headerWithName("Authorization").description("Access Token")
+                        )
                         .requestFields(
-                            fieldWithPath("nonMemberId").description("비회원 ID"),
                             fieldWithPath("sid").description("장소 ID")
                         )
                 )

--- a/Ping-Application/src/main/kotlin/com/ping/application/ping/dto/SaveMemberPing.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/ping/dto/SaveMemberPing.kt
@@ -2,7 +2,6 @@ package com.ping.application.ping.dto
 
 interface SaveMemberPing {
     data class Request(
-        val nonMemberId: Long,
         val sid: String
     )
 }

--- a/Ping-Application/src/main/kotlin/com/ping/application/ping/dto/SaveMemberPing.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/ping/dto/SaveMemberPing.kt
@@ -1,0 +1,8 @@
+package com.ping.application.ping.dto
+
+interface SaveMemberPing {
+    data class Request(
+        val nonMemberId: Long,
+        val sid: String
+    )
+}

--- a/Ping-Application/src/main/kotlin/com/ping/application/ping/service/PingService.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/ping/service/PingService.kt
@@ -15,7 +15,6 @@ import com.ping.domain.ping.aggregate.*
 import com.ping.domain.ping.repository.*
 import com.ping.domain.ping.service.PingUrlService
 import com.ping.support.jwt.JwtProvider
-import com.ping.support.jwt.JwtTokenManager
 import com.ping.support.jwt.JwtUtil
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.stereotype.Service

--- a/Ping-Application/src/main/kotlin/com/ping/application/ping/service/PingService.kt
+++ b/Ping-Application/src/main/kotlin/com/ping/application/ping/service/PingService.kt
@@ -15,6 +15,8 @@ import com.ping.domain.ping.aggregate.*
 import com.ping.domain.ping.repository.*
 import com.ping.domain.ping.service.PingUrlService
 import com.ping.support.jwt.JwtProvider
+import com.ping.support.jwt.JwtTokenManager
+import com.ping.support.jwt.JwtUtil
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -35,6 +37,7 @@ class PingService(
     private val recommendPlaceRepository: RecommendPlaceRepository,
     private val pingUrlService: PingUrlService,
     private val jwtProvider: JwtProvider,
+    private val jwtUtil: JwtUtil,
 ) {
 
     @Transactional
@@ -79,11 +82,10 @@ class PingService(
     @Transactional
     fun saveMemberPing(request: SaveMemberPing.Request, httpRequest: HttpServletRequest) {
         jwtProvider.validateToken(httpRequest)
-
-        val nonMemberId = request.nonMemberId
+        val nonMemberId = jwtUtil.getNonMemberId(httpRequest)
         val sid = request.sid
 
-        val nonMember = NonMemberDomain.validateExists(request.nonMemberId, nonMemberRepository)
+        val nonMember = NonMemberDomain.validateExists(nonMemberId, nonMemberRepository)
         BookmarkDomain.validateSidExists(sid, bookmarkRepository)
         NonMemberPlaceDomain.validateNoDuplicate(nonMemberId, sid, nonMemberPlaceRepository)
 

--- a/Ping-Common/src/main/kotlin/com/ping/common/enums/PlaceType.kt
+++ b/Ping-Common/src/main/kotlin/com/ping/common/enums/PlaceType.kt
@@ -1,0 +1,6 @@
+package com.ping.common.enums
+
+enum class PlaceType {
+    CRAWLED,
+    MEMBER_ADDED
+}

--- a/Ping-Common/src/main/kotlin/com/ping/common/exception/ExceptionContent.kt
+++ b/Ping-Common/src/main/kotlin/com/ping/common/exception/ExceptionContent.kt
@@ -28,5 +28,10 @@ enum class ExceptionContent(
     TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "TOKEN",2,"토큰이 요청 헤더에 없습니다."),
     TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "TOKEN",3,"해당 토큰은 사용이 금지되었습니다. 다시 로그인해 주세요."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN",4,"토큰이 만료되었습니다. 새로운 토큰을 발급받으세요."),
-    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN",5,"세션이 만료되었습니다. 다시 로그인해 주세요.")
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN",5,"세션이 만료되었습니다. 다시 로그인해 주세요."),
+
+    // NonMemberPlace 관련 예외
+    NON_MEMBER_PLACE_ALREADY_EXISTS(HttpStatus.CONFLICT, "NONMEMBERPLACE", 1, "이미 저장된 장소입니다. 다른 장소를 추가해주세요"),
+    NON_MEMBER_PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "NONMEMBERPLACE", 2, "해당 장소 정보는 존재하지 않습니다. 다른 장소를 추가해주세요."),
+
 }

--- a/Ping-Common/src/main/kotlin/com/ping/common/exception/GlobalExceptionHandler.kt
+++ b/Ping-Common/src/main/kotlin/com/ping/common/exception/GlobalExceptionHandler.kt
@@ -64,18 +64,6 @@ class GlobalExceptionHandler {
         return logAndGenerateErrorResponse(e, HttpStatus.NOT_FOUND, "Resource not found")
     }
 
-    // EmptyResultDataAccessException 처리
-    @ExceptionHandler(EmptyResultDataAccessException::class)
-    fun handleEmptyResultDataAccessException(e: EmptyResultDataAccessException): ResponseEntity<ErrorResponse<Nothing?>> {
-        return logAndGenerateErrorResponse(e, HttpStatus.NOT_FOUND, "Resource not found")
-    }
-
-    // HttpMessageNotReadableException 처리
-    @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleJsonException(e: HttpMessageNotReadableException): ResponseEntity<ErrorResponse<Nothing?>> {
-        return logAndGenerateErrorResponse(e, HttpStatus.BAD_REQUEST, "Invalid JSON format")
-    }
-
     // HttpRequestMethodNotSupportedException 처리
     @ExceptionHandler(HttpRequestMethodNotSupportedException::class)
     fun handleRequestMethodException(e: HttpRequestMethodNotSupportedException): ResponseEntity<ErrorResponse<Nothing?>> {

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/member/aggregate/NonMemberDomain.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/member/aggregate/NonMemberDomain.kt
@@ -1,6 +1,9 @@
 package com.ping.domain.member.aggregate
 
+import com.ping.common.exception.CustomException
+import com.ping.common.exception.ExceptionContent
 import com.ping.domain.event.aggregate.ShareUrlDomain
+import com.ping.domain.member.repository.NonMemberRepository
 
 data class NonMemberDomain(
     val id: Long,
@@ -11,12 +14,16 @@ data class NonMemberDomain(
     val shareUrlDomain: ShareUrlDomain
 ) {
     companion object {
-        fun of(
-            name: String,
+        fun of(name: String,
             password: String,
             profileSvg: String,
             profileLockSvg: String,
-            shareUrlDomain: ShareUrlDomain
+            shareUrlDomain: ShareUrlDomain,
         ) = NonMemberDomain(0L, name, password, profileSvg, profileLockSvg, shareUrlDomain)
+
+        fun validateExists(nonMemberId: Long, nonMemberRepository: NonMemberRepository): NonMemberDomain {
+            return nonMemberRepository.findById(nonMemberId)
+                ?: throw CustomException(ExceptionContent.NON_MEMBER_NOT_FOUND)
+        }
     }
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/BookmarkDomain.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/BookmarkDomain.kt
@@ -1,5 +1,9 @@
 package com.ping.domain.ping.aggregate
 
+import com.ping.common.exception.CustomException
+import com.ping.common.exception.ExceptionContent
+import com.ping.domain.ping.repository.BookmarkRepository
+
 data class BookmarkDomain (
     val name: String,
     val px: Double,
@@ -8,4 +12,12 @@ data class BookmarkDomain (
     val address: String,
     val mcidName: String,
     val url: String,
-)
+) {
+    companion object {
+        fun validateSidExists(sid: String, bookmarkRepository: BookmarkRepository) {
+            if (!bookmarkRepository.existsBySid(sid)) {
+                throw CustomException(ExceptionContent.NON_MEMBER_PLACE_NOT_FOUND)
+            }
+        }
+    }
+}

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/NonMemberPlaceDomain.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/NonMemberPlaceDomain.kt
@@ -1,6 +1,10 @@
 package com.ping.domain.ping.aggregate
 
+import com.ping.common.enums.PlaceType
+import com.ping.common.exception.CustomException
+import com.ping.common.exception.ExceptionContent
 import com.ping.domain.member.aggregate.NonMemberDomain
+import com.ping.domain.ping.repository.NonMemberPlaceRepository
 
 data class NonMemberPlaceDomain(
     val id: Long,
@@ -16,5 +20,29 @@ data class NonMemberPlaceDomain(
                 sid = sid,
                 placeType = placeType
             )
+
+        fun filterCrawledPlaces(domains: List<NonMemberPlaceDomain>): Set<String> {
+            return domains
+                .filter { it.placeType == PlaceType.CRAWLED }
+                .map { it.sid }
+                .toSet()
+        }
+
+        fun filterIdsToDelete(
+            domains: List<NonMemberPlaceDomain>,
+            nonMember: NonMemberDomain,
+            sidsToDelete: Set<String>
+        ): List<Long> {
+            return domains
+                .filter { it.nonMember == nonMember && it.sid in sidsToDelete }
+                .map { it.id }
+        }
+
+        fun validateNoDuplicate(nonMemberId: Long, sid: String, nonMemberPlaceRepository: NonMemberPlaceRepository) {
+            val existingPlace = nonMemberPlaceRepository.findByNonMemberIdAndSid(nonMemberId, sid)
+            if (existingPlace != null) {
+                throw CustomException(ExceptionContent.NON_MEMBER_PLACE_ALREADY_EXISTS)
+            }
+        }
     }
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/NonMemberPlaceDomain.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/NonMemberPlaceDomain.kt
@@ -5,9 +5,16 @@ import com.ping.domain.member.aggregate.NonMemberDomain
 data class NonMemberPlaceDomain(
     val id: Long,
     val nonMember: NonMemberDomain,
-    val sid: String
+    val sid: String,
+    val placeType: PlaceType
 ) {
     companion object {
-        fun of(nonMember: NonMemberDomain, sid: String) = NonMemberPlaceDomain(0L, nonMember, sid)
+        fun of(nonMember: NonMemberDomain, sid: String, placeType: PlaceType) =
+            NonMemberPlaceDomain(
+                id = 0L,
+                nonMember = nonMember,
+                sid = sid,
+                placeType = placeType
+            )
     }
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/PlaceType.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/PlaceType.kt
@@ -1,0 +1,6 @@
+package com.ping.domain.ping.aggregate
+
+enum class PlaceType {
+    CRAWLED,
+    USER_ADDED,
+}

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/PlaceType.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/ping/aggregate/PlaceType.kt
@@ -1,6 +1,0 @@
-package com.ping.domain.ping.aggregate
-
-enum class PlaceType {
-    CRAWLED,
-    USER_ADDED,
-}

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/ping/repository/BookmarkRepository.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/ping/repository/BookmarkRepository.kt
@@ -4,7 +4,7 @@ import com.ping.domain.ping.aggregate.BookmarkDomain
 
 interface BookmarkRepository {
     fun saveAll(bookmarkDomains: List<BookmarkDomain>) : List<BookmarkDomain>
-
     fun findAllBySidIn(sids: List<String>) : List<BookmarkDomain>
     fun findAllByLocationNear(px: Double, py: Double, distance: Double): List<BookmarkDomain>
+    fun existsBySid(sid: String): Boolean
 }

--- a/Ping-Domain/src/main/kotlin/com/ping/domain/ping/repository/NonMemberPlaceRepository.kt
+++ b/Ping-Domain/src/main/kotlin/com/ping/domain/ping/repository/NonMemberPlaceRepository.kt
@@ -4,6 +4,7 @@ import com.ping.domain.ping.aggregate.NonMemberPlaceDomain
 import com.ping.domain.ping.dto.SidCount
 
 interface NonMemberPlaceRepository {
+    fun save(nonMemberPlaceDomain: NonMemberPlaceDomain)
     fun saveAll(nonMemberPlaceDomains: List<NonMemberPlaceDomain>): List<NonMemberPlaceDomain>
 
     fun findAllByNonMemberId(nonMemberId: Long): List<NonMemberPlaceDomain>
@@ -13,4 +14,6 @@ interface NonMemberPlaceRepository {
     fun findCountBySidIn(sids: List<String>): List<SidCount>
 
     fun findAllByNonMemberIdIn(nonMemberIds: List<Long>): List<NonMemberPlaceDomain>
+
+    fun findByNonMemberIdAndSid(nonMemberId: Long, sid: String): NonMemberPlaceDomain?
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/ping/BookmarkRepositoryImpl.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/ping/BookmarkRepositoryImpl.kt
@@ -30,4 +30,7 @@ class BookmarkRepositoryImpl(
             }
     }
 
+    override fun existsBySid(sid: String): Boolean {
+        return bookmarkMongoRepository.existsBySid(sid)
+    }
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/ping/NonMemberPlaceRepositoryImpl.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/ping/NonMemberPlaceRepositoryImpl.kt
@@ -11,13 +11,20 @@ import org.springframework.stereotype.Repository
 class NonMemberPlaceRepositoryImpl(
     private val nonMemberPlaceJpaRepository: NonMemberPlaceJpaRepository
 ) : NonMemberPlaceRepository {
+    override fun save(nonMemberPlaceDomain: NonMemberPlaceDomain) {
+        val entity = NonMemberPlaceMapper.toEntity(nonMemberPlaceDomain)
+        nonMemberPlaceJpaRepository.save(entity)
+    }
+
     override fun saveAll(nonMemberPlaceDomains: List<NonMemberPlaceDomain>): List<NonMemberPlaceDomain> {
         return nonMemberPlaceJpaRepository.saveAll(nonMemberPlaceDomains.map { NonMemberPlaceMapper.toEntity(it) })
                 .map { NonMemberPlaceMapper.toDomain(it) }
     }
+
     override fun findAllByNonMemberId(nonMemberId: Long): List<NonMemberPlaceDomain> {
         return nonMemberPlaceJpaRepository.findAllByNonMemberId(nonMemberId).map { NonMemberPlaceMapper.toDomain(it) }
     }
+
     override fun deleteAll(ids: List<Long>) {
         nonMemberPlaceJpaRepository.deleteAllById(ids)
     }
@@ -29,5 +36,10 @@ class NonMemberPlaceRepositoryImpl(
     override fun findAllByNonMemberIdIn(nonMemberIds: List<Long>): List<NonMemberPlaceDomain> {
         return nonMemberPlaceJpaRepository.findAllByNonMemberIdIn(nonMemberIds)
                 .map { NonMemberPlaceMapper.toDomain(it) }
+    }
+
+    override fun findByNonMemberIdAndSid(nonMemberId: Long, sid: String): NonMemberPlaceDomain? {
+        return nonMemberPlaceJpaRepository.findByNonMemberIdAndSid(nonMemberId, sid)
+            ?.let { NonMemberPlaceMapper.toDomain(it) }
     }
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/entity/NonMemberPlaceEntity.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/entity/NonMemberPlaceEntity.kt
@@ -1,5 +1,6 @@
 package com.ping.infra.ping.jpa.entity
 
+import com.ping.common.enums.PlaceType
 import com.ping.infra.config.jpa.BaseTimeEntity
 import com.ping.infra.member.jpa.entity.NonMemberEntity
 import jakarta.persistence.*

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/entity/NonMemberPlaceEntity.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/entity/NonMemberPlaceEntity.kt
@@ -16,5 +16,9 @@ class NonMemberPlaceEntity(
     val nonMember: NonMemberEntity,
 
     @Column(nullable = false)
-    val sid: String
+    val sid: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val placeType: PlaceType,
 ) : BaseTimeEntity()

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/entity/PlaceType.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/entity/PlaceType.kt
@@ -1,6 +1,0 @@
-package com.ping.infra.ping.jpa.entity
-
-enum class PlaceType {
-    CRAWLED,
-    MEMBER_ADDED,
-}

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/entity/PlaceType.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/entity/PlaceType.kt
@@ -1,0 +1,6 @@
+package com.ping.infra.ping.jpa.entity
+
+enum class PlaceType {
+    CRAWLED,
+    MEMBER_ADDED,
+}

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/repository/NonMemberPlaceJpaRepository.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/ping/jpa/repository/NonMemberPlaceJpaRepository.kt
@@ -12,4 +12,6 @@ interface NonMemberPlaceJpaRepository : JpaRepository<NonMemberPlaceEntity, Long
     fun findCountBySidIn(sids: List<String>): List<SidCount>
 
     fun findAllByNonMemberIdIn(nonMemberIds: List<Long>): List<NonMemberPlaceEntity>
+
+    fun findByNonMemberIdAndSid(nonMemberId: Long, sid: String): NonMemberPlaceEntity?
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/ping/mapper/NonMemberPlaceMapper.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/ping/mapper/NonMemberPlaceMapper.kt
@@ -7,15 +7,16 @@ import com.ping.infra.ping.jpa.entity.NonMemberPlaceEntity
 object NonMemberPlaceMapper {
 
     fun toDomain(nonMemberPlaceEntity: NonMemberPlaceEntity) = NonMemberPlaceDomain(
-        nonMemberPlaceEntity.id,
-        NonMemberMapper.toDomain(nonMemberPlaceEntity.nonMember),
-        nonMemberPlaceEntity.sid
+        id = nonMemberPlaceEntity.id,
+        nonMember = NonMemberMapper.toDomain(nonMemberPlaceEntity.nonMember),
+        sid = nonMemberPlaceEntity.sid,
+        placeType = nonMemberPlaceEntity.placeType
     )
 
-
     fun toEntity(nonMemberPlaceDomain: NonMemberPlaceDomain) = NonMemberPlaceEntity(
-        nonMemberPlaceDomain.id,
-        NonMemberMapper.toEntity(nonMemberPlaceDomain.nonMember),
-        nonMemberPlaceDomain.sid
+        id = nonMemberPlaceDomain.id,
+        nonMember = NonMemberMapper.toEntity(nonMemberPlaceDomain.nonMember),
+        sid = nonMemberPlaceDomain.sid,
+        placeType = nonMemberPlaceDomain.placeType
     )
 }

--- a/Ping-Infra/src/main/kotlin/com/ping/infra/ping/mongo/repository/BookmarkMongoRepository.kt
+++ b/Ping-Infra/src/main/kotlin/com/ping/infra/ping/mongo/repository/BookmarkMongoRepository.kt
@@ -8,4 +8,5 @@ import org.springframework.data.mongodb.repository.MongoRepository
 interface BookmarkMongoRepository : MongoRepository<BookmarkEntity, String> {
     fun findAllBySidIn(sids: List<String>) : List<BookmarkEntity>
     fun findAllByLocationNear(location: GeoJsonPoint, distance: Distance): List<BookmarkEntity>
+    fun existsBySid(sid: String): Boolean
 }

--- a/Ping-Support/src/main/kotlin/com/ping/support/jwt/JwtProvider.kt
+++ b/Ping-Support/src/main/kotlin/com/ping/support/jwt/JwtProvider.kt
@@ -83,7 +83,7 @@ class JwtProvider(
         return true
     }
 
-    private fun resolveToken(request: HttpServletRequest): String {
+    fun resolveToken(request: HttpServletRequest): String {
         val jwtToken = request.getHeader("Authorization") ?: throw CustomException(ExceptionContent.TOKEN_MISSING)
 
         return if (jwtToken.startsWith("Bearer ")) {

--- a/Ping-Support/src/main/kotlin/com/ping/support/jwt/JwtProvider.kt
+++ b/Ping-Support/src/main/kotlin/com/ping/support/jwt/JwtProvider.kt
@@ -93,11 +93,13 @@ class JwtProvider(
         }
     }
 
-    private fun handleTokenExceptions(exception: Throwable): Boolean {
-        return when (exception) {
+    private fun handleTokenExceptions(exception: Throwable): Nothing {
+        when (exception) {
+            is CustomException -> throw exception
             is ExpiredJwtException -> throw CustomException(ExceptionContent.TOKEN_EXPIRED)
             is UnsupportedJwtException, is MalformedJwtException -> throw CustomException(ExceptionContent.TOKEN_INVALID)
-            else -> false
+            else -> throw CustomException(ExceptionContent.TOKEN_INVALID)
         }
     }
+
 }

--- a/Ping-Support/src/main/kotlin/com/ping/support/jwt/JwtUtil.kt
+++ b/Ping-Support/src/main/kotlin/com/ping/support/jwt/JwtUtil.kt
@@ -1,0 +1,17 @@
+package com.ping.support.jwt
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.stereotype.Component
+
+@Component
+class JwtUtil (
+    private val jwtProvider: JwtProvider,
+    private val jwtTokenManager: JwtTokenManager,
+){
+    fun getNonMemberId(request: HttpServletRequest): Long {
+        val accessToken = jwtProvider.resolveToken(request)
+        val claims = jwtTokenManager.parseClaims(accessToken)
+        val memberId = claims.subject
+        return memberId.toLong()
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #60

## 📝작업 내용

- [x] 다른 멤버의 모핑 추가 API 엔드포인트 설계 및 구현
- [x] NonMemberPlace 테이블 설계 변경
- [x] 테이블 변경에 따른 update, refresh 로직 수정
- [x] 테스트 코드 작성
- [x] Swagger & Rest Docs API 문서화

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/389d9243-f12c-49dd-a16e-91e22fff7009)
![image](https://github.com/user-attachments/assets/d824058f-f093-428a-8784-44be9b2681e1)

## 💬리뷰 요구사항(선택)

> 최대한 도메인 특화 로직은 도메인 레이어에서 작성하였습니다.
