### PR TITLE
[feat] 검색 기능 개선 - 특정 키워드 검색 시 관련 결과 교차 반환

### DIFF
--- a/Ping-Common/src/main/kotlin/com/ping/common/util/AlternativeQueryProvider.kt
+++ b/Ping-Common/src/main/kotlin/com/ping/common/util/AlternativeQueryProvider.kt
@@ -2,7 +2,7 @@ package com.ping.common.util
 
 object AlternativeQueryProvider {
     private val alternativeQueries = mapOf(
-        "을지로" to listOf("을지로3가", "을지로입구")
+        "을지로" to listOf("을지로3가", "을지로4가", "을지로입구")
     )
 
     fun getQueries(keyword: String): List<String> {

--- a/Ping-Common/src/main/kotlin/com/ping/common/util/AlternativeQueryProvider.kt
+++ b/Ping-Common/src/main/kotlin/com/ping/common/util/AlternativeQueryProvider.kt
@@ -1,0 +1,11 @@
+package com.ping.common.util
+
+object AlternativeQueryProvider {
+    private val alternativeQueries = mapOf(
+        "을지로" to listOf("을지로3가", "을지로입구")
+    )
+
+    fun getQueries(keyword: String): List<String> {
+        return alternativeQueries[keyword] ?: listOf(keyword)
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62

## 📝작업 내용

- [x] '을지로' 키워드에 대해 대체 검색어 목록(을지로3가, 을지로입구)을 설정
- [x] 대체 검색어 관리 기능을 별도의 클래스로 분리하여 모듈화
- [x] 각 키워드별 네이버 API 검색 결과를 순위별로 교차하여 합치는 로직 구현

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ee33bf30-49fa-4df1-b360-22cf9e5f8f46)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
